### PR TITLE
spike markers

### DIFF
--- a/Gui_functions/Plot_continuous_data.m
+++ b/Gui_functions/Plot_continuous_data.m
@@ -84,7 +84,7 @@ if nargin==6
                 clr=colors(1+mod(i-1,length(colors)),:);
                 % make the color a little bit lighter to ease
                 % its visual perception on the white background
-                clr=min([1 1 1],clr+[.2 .2 .2]);
+                clr=clr+(1-clr).*.25;
             else
                 % cluster 0 plotted in black
                 clr=[0 0 0];

--- a/Gui_functions/Plot_continuous_data.m
+++ b/Gui_functions/Plot_continuous_data.m
@@ -44,12 +44,29 @@ ylim(handles.cont_data,yl);
 
 if nargin==6
     % mark positions of detected spikes
+
     hold on
-    % y-position where to plot spike markers
-    ylm=ylim(handles.cont_data);
-    yTop=ylm(2);
-    yBottom=yTop-diff(ylm)/5;
-    %
+
+    % update ylim to leave more space for markers and 
+    % compute y-position where to plot spike markers
+    ylo=yl;
+    switch detect
+        case 'pos'
+            yl=[yl(1) yl(2)*1.2];
+            y1=[yl(2) ylo(2)];
+            y2=[];
+        case 'neg'
+            yl=[yl(1)*1.2 yl(2)];
+            y1=[yl(1) ylo(1)];
+            y2=[];
+        case 'both'
+            yl=yl*1.2;
+            y1=[yl(2) ylo(2)];
+            y2=[yl(1) ylo(1)];
+    end
+    ylim(handles.cont_data,yl);
+
+    % plot
     for i=0:max(spikesClass)
         idx=find(spikesClass==i);
         n=length(idx);
@@ -67,8 +84,12 @@ if nargin==6
             xx=spikesIdx(idx);
             % force them to form a row vector
             if size(xx,1)>1 xx=xx'; end
-            plot(handles.cont_data, repmat(xx,2,1)/1000,repmat([yBottom yTop]',1,n),...
+            plot(handles.cont_data, repmat(xx,2,1)/1000,repmat(y1',1,n),...
                 'color',clr,'LineWidth',3);
+            if ~isempty(y2)
+                plot(handles.cont_data, repmat(xx,2,1)/1000,repmat(y2',1,n),...
+                    'color',clr,'LineWidth',3);
+            end
         end
     end
     hold off

--- a/Gui_functions/Plot_continuous_data.m
+++ b/Gui_functions/Plot_continuous_data.m
@@ -1,10 +1,13 @@
-function Plot_continuous_data(xf_detect, sr_sub,handles, spikesIdx, spikesClass, colors)
+function spikeMarkers=Plot_continuous_data(xf_detect, sr_sub,handles, spikesIdx, spikesClass, colors)
 % Function that plot the segment of continuous data. 
 % It will try to plot a minute, maximun.
 % Optional arguments:
 %   - spikesIdx - indices of samples of detected spikes
 %   - spikesClass - classes of detected spikes
 %   - colors - cluster colors
+%
+% If supplied with 5 arguments, spikeMarkers (a 1x2 cell array of arrays of handles to
+% plotted spike marker lines) get returned.
 
 detect = handles.par.detection;
 stdmin = handles.par.stdmin;
@@ -67,6 +70,12 @@ if nargin==6
     ylim(handles.cont_data,yl);
 
     % plot
+    spikeMarkers=repmat(0,1,length(spikesClass));
+    if ~isempty(y2)
+        spikeMarkers2=repmat(0,1,length(spikesClass));
+    else
+        spikeMarkers2=[];
+    end
     for i=0:max(spikesClass)
         idx=find(spikesClass==i);
         n=length(idx);
@@ -84,14 +93,17 @@ if nargin==6
             xx=spikesIdx(idx);
             % force them to form a row vector
             if size(xx,1)>1 xx=xx'; end
-            plot(handles.cont_data, repmat(xx,2,1)/1000,repmat(y1',1,n),...
+            p=plot(handles.cont_data, repmat(xx,2,1)/1000,repmat(y1',1,n),...
                 'color',clr,'LineWidth',3);
+            spikeMarkers(idx)=p;
             if ~isempty(y2)
-                plot(handles.cont_data, repmat(xx,2,1)/1000,repmat(y2',1,n),...
+                p=plot(handles.cont_data, repmat(xx,2,1)/1000,repmat(y2',1,n),...
                     'color',clr,'LineWidth',3);
+                spikeMarkers2(idx)=p;
             end
         end
     end
+    spikeMarkers={spikeMarkers,spikeMarkers2};
     hold off
 end
 

--- a/Gui_functions/Plot_continuous_data.m
+++ b/Gui_functions/Plot_continuous_data.m
@@ -1,6 +1,10 @@
-function Plot_continuous_data(xf_detect, sr_sub,handles)
+function Plot_continuous_data(xf_detect, sr_sub,handles, spikesIdx, spikesClass, colors)
 % Function that plot the segment of continuous data. 
 % It will try to plot a minute, maximun.
+% Optional arguments:
+%   - spikesIdx - indices of samples of detected spikes
+%   - spikesClass - classes of detected spikes
+%   - colors - cluster colors
 
 detect = handles.par.detection;
 stdmin = handles.par.stdmin;
@@ -37,5 +41,37 @@ yl = ylim(handles.cont_data);
 plot(handles.cont_data, [0 lx/sr_sub], [throut throut],':r')
 plot(handles.cont_data, [0 lx/sr_sub], [-throut -throut],':r')
 ylim(handles.cont_data,yl);
+
+if nargin==6
+    % mark positions of detected spikes
+    hold on
+    % y-position where to plot spike markers
+    ylm=ylim(handles.cont_data);
+    yTop=ylm(2);
+    yBottom=yTop-diff(ylm)/5;
+    %
+    for i=0:max(spikesClass)
+        idx=find(spikesClass==i);
+        n=length(idx);
+        if ~isempty(idx)
+            if i>0
+                clr=colors(1+mod(i-1,length(colors)),:);
+                % make the color a little bit lighter to ease
+                % its visual perception on the white background
+                clr=min([1 1 1],clr+[.2 .2 .2]);
+            else
+                % cluster 0 plotted in black
+                clr=[0 0 0];
+            end
+            % samples of detected spikes
+            xx=spikesIdx(idx);
+            % force them to form a row vector
+            if size(xx,1)>1 xx=xx'; end
+            plot(handles.cont_data, repmat(xx,2,1)/1000,repmat([yBottom yTop]',1,n),...
+                'color',clr,'LineWidth',3);
+        end
+    end
+    hold off
+end
 
 %xlabel('Time (sec)')

--- a/Gui_functions/Plot_continuous_data.m
+++ b/Gui_functions/Plot_continuous_data.m
@@ -84,7 +84,7 @@ if nargin==6
                 clr=colors(1+mod(i-1,length(colors)),:);
                 % make the color a little bit lighter to ease
                 % its visual perception on the white background
-                clr=clr+(1-clr).*.25;
+                clr=clr+(1-clr).*.35;
             else
                 % cluster 0 plotted in black
                 clr=[0 0 0];

--- a/Gui_functions/colorSpikeMarkers.m
+++ b/Gui_functions/colorSpikeMarkers.m
@@ -14,7 +14,7 @@ function colorSpikeMarkers(spikeMarkers, spikesClass, colors)
                 clr=colors(1+mod(i-1,length(colors)),:);
                 % make the color a little bit lighter to ease
                 % its visual perception on the white background
-                clr=min([1 1 1],clr+[.2 .2 .2]);
+                clr=clr+(1-clr).*.25;
             else
                 % cluster 0 plotted in black
                 clr=[0 0 0];

--- a/Gui_functions/colorSpikeMarkers.m
+++ b/Gui_functions/colorSpikeMarkers.m
@@ -14,7 +14,7 @@ function colorSpikeMarkers(spikeMarkers, spikesClass, colors)
                 clr=colors(1+mod(i-1,length(colors)),:);
                 % make the color a little bit lighter to ease
                 % its visual perception on the white background
-                clr=clr+(1-clr).*.25;
+                clr=clr+(1-clr).*.35;
             else
                 % cluster 0 plotted in black
                 clr=[0 0 0];

--- a/Gui_functions/colorSpikeMarkers.m
+++ b/Gui_functions/colorSpikeMarkers.m
@@ -1,0 +1,28 @@
+function colorSpikeMarkers(spikeMarkers, spikesClass, colors)
+% Function that colors spike markers (tiny lines in the trace plot
+% created by Plot_continuous_data) according to the current clusters.
+% Arguments:
+%   spikesMarkers - 1x2 cell array of arrays of handles to spike markers
+%   spikesClass - classes of spikes
+%   colors - cluster colors
+%
+
+    for i=0:max(spikesClass)
+        idx=find(spikesClass==i);
+        if ~isempty(idx)
+            if i>0
+                clr=colors(1+mod(i-1,length(colors)),:);
+                % make the color a little bit lighter to ease
+                % its visual perception on the white background
+                clr=min([1 1 1],clr+[.2 .2 .2]);
+            else
+                % cluster 0 plotted in black
+                clr=[0 0 0];
+            end
+            set(spikeMarkers{1}(idx),'color',clr);
+            if ~isempty(spikeMarkers{2})
+                set(spikeMarkers{2}(idx),'color',clr);
+            end
+        end
+    end
+end

--- a/Gui_functions/color_spike_markers.m
+++ b/Gui_functions/color_spike_markers.m
@@ -1,4 +1,4 @@
-function colorSpikeMarkers(spikeMarkers, spikesClass, colors)
+function color_spike_markers(spikeMarkers, spikesClass, colors)
 % Function that colors spike markers (tiny lines in the trace plot
 % created by Plot_continuous_data) according to the current clusters.
 % Arguments:

--- a/Gui_functions/plot_spikes.m
+++ b/Gui_functions/plot_spikes.m
@@ -383,7 +383,7 @@ end
 % mark detected and currently assigned spikes in the amplitude trace plot
 if length(USER_DATA)>=55 && ~isempty(USER_DATA{55})
     % if spike markers have already been plotted, just color them
-    colorSpikeMarkers(USER_DATA{55}, USER_DATA{6}, colors);
+    color_spike_markers(USER_DATA{55}, USER_DATA{6}, colors);
 elseif length(USER_DATA)>=53 && ~isempty(USER_DATA{53}) % if signal sample has been cached
     % plot spike markers and cache them
     spikeMarkers=Plot_continuous_data(USER_DATA{53}, USER_DATA{54}, handles, USER_DATA{3}, USER_DATA{6}, colors);

--- a/Gui_functions/plot_spikes.m
+++ b/Gui_functions/plot_spikes.m
@@ -381,9 +381,9 @@ if ~isempty(USER_DATA{5})
 end
 
 % mark detected and currently assigned spikes in the amplitude trace plot
-data_handler = readInData(handles.par);
-[xd_sub, sr_sub] = data_handler.get_signal_sample();
-Plot_continuous_data(xd_sub, sr_sub, handles, USER_DATA{3}, USER_DATA{6}, colors);
+if ~isempty(USER_DATA{53}) % if signal sample has been cached
+    Plot_continuous_data(USER_DATA{53}, USER_DATA{54}, handles, USER_DATA{3}, USER_DATA{6}, colors);
+end
 
 set(handles.file_name,'string', par.file_name_to_show);
 axes(handles.projections)

--- a/Gui_functions/plot_spikes.m
+++ b/Gui_functions/plot_spikes.m
@@ -379,6 +379,12 @@ end
 if ~isempty(USER_DATA{5})
     mark_clusters_temperature_diagram(handles,USER_DATA{5},clustering_results)
 end
+
+% mark detected and currently assigned spikes in the amplitude trace plot
+data_handler = readInData(handles.par);
+[xd_sub, sr_sub] = data_handler.get_signal_sample();
+Plot_continuous_data(xd_sub, sr_sub, handles, USER_DATA{3}, USER_DATA{6}, colors);
+
 set(handles.file_name,'string', par.file_name_to_show);
 axes(handles.projections)
 drawnow

--- a/Gui_functions/plot_spikes.m
+++ b/Gui_functions/plot_spikes.m
@@ -381,8 +381,14 @@ if ~isempty(USER_DATA{5})
 end
 
 % mark detected and currently assigned spikes in the amplitude trace plot
-if ~isempty(USER_DATA{53}) % if signal sample has been cached
-    Plot_continuous_data(USER_DATA{53}, USER_DATA{54}, handles, USER_DATA{3}, USER_DATA{6}, colors);
+if ~isempty(USER_DATA{55})
+    % if spike markers have already been plotted, just color them
+    colorSpikeMarkers(USER_DATA{55}, USER_DATA{6}, colors);
+elseif ~isempty(USER_DATA{53}) % if signal sample has been cached
+    % plot spike markers and cache them
+    spikeMarkers=Plot_continuous_data(USER_DATA{53}, USER_DATA{54}, handles, USER_DATA{3}, USER_DATA{6}, colors);
+    USER_DATA{55}=spikeMarkers;
+    set(handles.wave_clus_figure,'userdata',USER_DATA);
 end
 
 set(handles.file_name,'string', par.file_name_to_show);

--- a/Gui_functions/plot_spikes.m
+++ b/Gui_functions/plot_spikes.m
@@ -381,10 +381,10 @@ if ~isempty(USER_DATA{5})
 end
 
 % mark detected and currently assigned spikes in the amplitude trace plot
-if ~isempty(USER_DATA{55})
+if length(USER_DATA)>=55 && ~isempty(USER_DATA{55})
     % if spike markers have already been plotted, just color them
     colorSpikeMarkers(USER_DATA{55}, USER_DATA{6}, colors);
-elseif ~isempty(USER_DATA{53}) % if signal sample has been cached
+elseif length(USER_DATA)>=53 && ~isempty(USER_DATA{53}) % if signal sample has been cached
     % plot spike markers and cache them
     spikeMarkers=Plot_continuous_data(USER_DATA{53}, USER_DATA{54}, handles, USER_DATA{3}, USER_DATA{6}, colors);
     USER_DATA{55}=spikeMarkers;

--- a/wave_clus.m
+++ b/wave_clus.m
@@ -46,6 +46,7 @@ function varargout = wave_clus(varargin)
 % USER_DATA{20} - USER_DATA{42}, fix clusters
 % USER_DATA{53} = signal sample being plotted by Plot_continuous_data
 % USER_DATA{54} = sampling frequency of the signal sample being plotted by Plot_continuous_data
+% USER_DATA{55} = spike markers plotted by Plot_continuous_data and colored by colorSpikeMarkers
 
 % Begin initialization code - DO NOT EDIT
 gui_Singleton = 1;
@@ -245,6 +246,7 @@ if (data_handler.with_raw || data_handler.with_psegment) && handles.par.cont_seg
     % cache the signal sample for later calls to Plot_continuous_data
     USER_DATA{53}=xd_sub;
     USER_DATA{54}=sr_sub;
+    USER_DATA{55}=[]; % initially, there are no spike markers
     set(handles.wave_clus_figure,'userdata',USER_DATA);
     Plot_continuous_data(xd_sub, sr_sub, handles); drawnow
     clear xd_sub

--- a/wave_clus.m
+++ b/wave_clus.m
@@ -46,7 +46,7 @@ function varargout = wave_clus(varargin)
 % USER_DATA{20} - USER_DATA{42}, fix clusters
 % USER_DATA{53} = signal sample being plotted by Plot_continuous_data
 % USER_DATA{54} = sampling frequency of the signal sample being plotted by Plot_continuous_data
-% USER_DATA{55} = spike markers plotted by Plot_continuous_data and colored by colorSpikeMarkers
+% USER_DATA{55} = spike markers plotted by Plot_continuous_data and colored by color_spike_markers
 
 % Begin initialization code - DO NOT EDIT
 gui_Singleton = 1;

--- a/wave_clus.m
+++ b/wave_clus.m
@@ -44,6 +44,8 @@ function varargout = wave_clus(varargin)
 % USER_DATA{16} = rejected_bk,  backup boolean vector for rejected spikes. Vector only used in develop mode.
 % USER_DATA{17} - USER_DATA{19}, for future changes
 % USER_DATA{20} - USER_DATA{42}, fix clusters
+% USER_DATA{53} = signal sample being plotted by Plot_continuous_data
+% USER_DATA{54} = sampling frequency of the signal sample being plotted by Plot_continuous_data
 
 % Begin initialization code - DO NOT EDIT
 gui_Singleton = 1;
@@ -240,6 +242,10 @@ handles.par.file_name_to_show = [pathname filename];
 
 if (data_handler.with_raw || data_handler.with_psegment) && handles.par.cont_segment         %raw exists
     [xd_sub, sr_sub] = data_handler.get_signal_sample();
+    % cache the signal sample for later calls to Plot_continuous_data
+    USER_DATA{53}=xd_sub;
+    USER_DATA{54}=sr_sub;
+    set(handles.wave_clus_figure,'userdata',USER_DATA);
     Plot_continuous_data(xd_sub, sr_sub, handles); drawnow
     clear xd_sub
 end

--- a/wave_clus.m
+++ b/wave_clus.m
@@ -241,15 +241,19 @@ end
 
 handles.par.file_name_to_show = [pathname filename];
 
+USER_DATA = get(handles.wave_clus_figure,'userdata');
 if (data_handler.with_raw || data_handler.with_psegment) && handles.par.cont_segment         %raw exists
     [xd_sub, sr_sub] = data_handler.get_signal_sample();
     % cache the signal sample for later calls to Plot_continuous_data
-    USER_DATA{53}=xd_sub;
-    USER_DATA{54}=sr_sub;
-    USER_DATA{55}=[]; % initially, there are no spike markers
-    set(handles.wave_clus_figure,'userdata',USER_DATA);
+    USER_DATA{53} = xd_sub;
+    USER_DATA{54} = sr_sub;
+    USER_DATA{55} = []; % initially, there are no spike markers
     Plot_continuous_data(xd_sub, sr_sub, handles); drawnow
     clear xd_sub
+else
+    USER_DATA{53}=[];
+    USER_DATA{54}=[];
+    USER_DATA{55}=[]; % initially, there are no spike markers
 end
 
 %Fixing lost elements of clu . Skiped elements will be  class -1 because in
@@ -272,7 +276,6 @@ elseif ~isempty(clu)
     clu = clu_aux;
     clear clu_aux
 end
-USER_DATA = get(handles.wave_clus_figure,'userdata');
 USER_DATA{1} = handles.par;
 USER_DATA{2} = spikes;
 USER_DATA{3} = index;


### PR DESCRIPTION
I propose to add an option that would show where in the original signal reside detected and the currently sorted spikes. This could be achieved e.g. by plotting small vertical bars at individual peaks, as can be shown in the amplitude trace here:

![wave_clus_marker_demo](https://cloud.githubusercontent.com/assets/1840074/21053133/594e75e6-be28-11e6-8203-f2f3e492aa12.png)

This option is extremely useful e.g. when considering whether to accept or reject a cluster of low-amplitude spikes: the position of such spikes, as revealed by the spike markers, can demonstrate that such spikes pose artifacts or spurious peaks, not real spikes (as was the example case above).

I've sketched an implementation of this feature and am sending a pull request.
At the same time, I think it would be nice to have this option configurable (e.g. using a parameter in the parameters file?), but I did not want to change much code, so if you decide to merge my proposal, please consider making it configurable somehow (perhaps disabled by default?).

Also, please note that in `plotSpikes.m`, I got the signal to plot from `handles`:
```
data_handler = readInData(handles.par);
[xd_sub, sr_sub] = data_handler.get_signal_sample();
```
which may not be optimal. Maybe, the signal is cached somewhere, and can be retrieved much easier from there?
