### PR TITLE
Enabled call of load_data_button() through wave_clus() callback

### DIFF
--- a/wave_clus.m
+++ b/wave_clus.m
@@ -91,7 +91,7 @@ set(handles.fix3_button,'value',0);
 guidata(hObject, handles);
 
 if nargin>3 && ischar(varargin{1})
-      load_data_button_Callback(varargin{1},'w_arg',handles)
+      load_data_button_Callback('w_arg',varargin{1},handles)
 end
 
 % UIWAIT makes wave_clus wait for user response (see UIRESUME)
@@ -120,12 +120,12 @@ set(0,'DefaultAxesColorOrder',clus_colors)
 function load_data_button_Callback(hObject, eventdata, handles)
 % select file
 
-if ischar(hObject) && strcmp(eventdata,'w_arg')
-    if isempty(fileparts(hObject))
-        filename = hObject;
+if ischar(eventdata)
+    if isempty(fileparts(eventdata))
+        filename = eventdata;
         pathname = [pwd filesep];
     else
-        [pathname filename ext]=fileparts(hObject);
+        [pathname filename ext]=fileparts(eventdata);
         pathname = [pathname filesep];
         filename = [filename ext];
     end


### PR DESCRIPTION
At the moment, it is not possible to call load_data_button_Callback() through wave_clus('load_data_button_Callback', ...); as gui_mainfcn() forces its first argument to be the figure itself, but load_data_button_Callback() expects the first argument be the file path (otherwise it prompts the user for the file, which defeats the purpose of calling this callback programmatically).

This simple change therefore makes the second argument of load_data_button_Callback() to be the file path should it be provided. After that, the user can call change the loaded file of a WaveClus instance with the simple call: wave_clus('load_data_button_Callback', hFig, pathToFile, guidata(hFig));

Thanks!